### PR TITLE
Note drivers are clones

### DIFF
--- a/docs/hardware/mainboard.md
+++ b/docs/hardware/mainboard.md
@@ -8,7 +8,7 @@ The stock mainboard of both the **Go** and the **Neo** is the "TriGorilla V_3.0.
 
 It is a 32bit 24V mainboard with a Huada HC32F460 KCTA ARM Cortex-M4 with 192KB SRAM and 512KB Flash.  
 The speed  of the ARM chip is listed as 200MHz by the manufacturer.  
-The mainboard comes with TMC2208 silent stepper drivers *soldered* onto the board (they can't be swapped out!).  
+The mainboard comes with TMC2208 silent stepper drivers *soldered* onto the board (they can't be swapped out!).  At least some motherboards are known to use the GC6609 clone driver.  It is not currently known if any motherboards use genuine TMC drivers.
 It offers a microSD card reader, a USB-C connector and a 10 pin connector for adding the control unit.    
   
 ![Mainboard TriGorilla front](../assets/images/mainboard_front_web.jpg)  


### PR DESCRIPTION
It has recently been discovered that at least some, if not all, motherboards actually use the GC6609 clone driver instead of genuine TMC2208s.  The 6609 is allegedly a clone of the TMC2209, however, it is not known if any of the advanced features of the TMC2209 such as sensorless homing or linear-advance compatibility are included in the clone, or if it is closer to a TMC2208.  This may have implications for some boards being able to use LA without the marlin bugfix for TMC2208s.

Nevertheless, it seemed prudent to update this to reflect reality.